### PR TITLE
Support Symfony ^2.8, too

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,8 +8,8 @@
         }
     ],
     "require": {
-        "symfony/console": "^3.2",
-        "symfony/process": "^3.2"
+        "symfony/console": "^2.8 || ^3.2",
+        "symfony/process": "^2.8 || ^3.2"
     },
     "autoload": {
         "psr-4": {"Fusonic\\SuluSyncBundle\\": ""}


### PR DESCRIPTION
Changed version constraints of `symfony/console` & `symfony/process`. 