### PR TITLE
Ability to connect to a MySQL via a different TCP port

### DIFF
--- a/Command/ExportCommand.php
+++ b/Command/ExportCommand.php
@@ -30,6 +30,7 @@ class ExportCommand extends Command
 
     private $secret;
     private $databaseHost;
+    private $databasePort;
     private $databaseUser;
     private $databaseName;
     private $databasePassword;
@@ -39,6 +40,7 @@ class ExportCommand extends Command
     public function __construct(
         $secret,
         $databaseHost,
+        $databasePort,
         $databaseName,
         $databaseUser,
         $databasePassword,
@@ -48,6 +50,7 @@ class ExportCommand extends Command
 
         $this->secret = $secret;
         $this->databaseHost = $databaseHost;
+        $this->databasePort = is_null($databasePort) ? 3306 : $databasePort;
         $this->databaseUser = $databaseUser;
         $this->databaseName = $databaseName;
         $this->databasePassword = $databasePassword;
@@ -97,7 +100,7 @@ class ExportCommand extends Command
     {
         $this->progressBar->setMessage("Exporting database...");
         $command =
-            "mysqldump -h {$this->databaseHost} -u " . escapeshellarg($this->databaseUser) .
+            "mysqldump -h {$this->databaseHost} -P {$this->databasePort} -u " . escapeshellarg($this->databaseUser) .
             ($this->databasePassword ? " -p" . escapeshellarg($this->databasePassword) : "") .
             " " . escapeshellarg($this->databaseName) . " > " . $this->exportDirectory . DIRECTORY_SEPARATOR . "{$this->secret}.sql";
 

--- a/Command/ImportCommand.php
+++ b/Command/ImportCommand.php
@@ -31,6 +31,7 @@ class ImportCommand extends Command
 
     private $secret;
     private $databaseHost;
+    private $databasePort;
     private $databaseUser;
     private $databaseName;
     private $databasePassword;
@@ -39,6 +40,7 @@ class ImportCommand extends Command
     public function __construct(
         $secret,
         $databaseHost,
+        $databasePort,
         $databaseName,
         $databaseUser,
         $databasePassword,
@@ -48,6 +50,7 @@ class ImportCommand extends Command
 
         $this->secret = $secret;
         $this->databaseHost = $databaseHost;
+        $this->databasePort = is_null($databasePort) ? 3306 : $databasePort;
         $this->databaseUser = $databaseUser;
         $this->databaseName = $databaseName;
         $this->databasePassword = $databasePassword;
@@ -162,7 +165,7 @@ class ImportCommand extends Command
         $this->progressBar->setMessage("Importing database...");
         $filename = $this->getTempPath(".sql");
         $command =
-            "mysql -h {$this->databaseHost} -u " . escapeshellarg($this->databaseUser) .
+            "mysql -h {$this->databaseHost} -P {$this->databasePort} -u " . escapeshellarg($this->databaseUser) .
             ($this->databasePassword ? " -p" . escapeshellarg($this->databasePassword) : "") .
             " " . escapeshellarg($this->databaseName) . " < " . "{$filename}";
 

--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -9,6 +9,7 @@
             <tag name="console.command"/>
             <argument>%secret%</argument>
             <argument>%database_host%</argument>
+            <argument>%database_port%</argument>
             <argument>%database_name%</argument>
             <argument>%database_user%</argument>
             <argument>%database_password%</argument>
@@ -19,6 +20,7 @@
             <tag name="console.command"/>
             <argument>%secret%</argument>
             <argument>%database_host%</argument>
+            <argument>%database_port%</argument>
             <argument>%database_name%</argument>
             <argument>%database_user%</argument>
             <argument>%database_password%</argument>


### PR DESCRIPTION
Some companies run MySQL/MariaDB on a different port (like we do) than the default (3306). This PR has them covered.